### PR TITLE
Rename environment variables to CLIENT_SECRET and CLIENT_ID

### DIFF
--- a/foundation/src/main/java/com/lambdaschool/marketplace/UserModelApplication.java
+++ b/foundation/src/main/java/com/lambdaschool/marketplace/UserModelApplication.java
@@ -42,8 +42,8 @@ public class UserModelApplication {
    */
   public static void main(String[] args) {
     // Check to see if the environment variables exists. If they do not, stop execution of application.
-    checkEnvironmentVariable("OAUTHCLIENTID");
-    checkEnvironmentVariable("OAUTHCLIENTSECRET");
+    checkEnvironmentVariable("CLIENT_ID");
+    checkEnvironmentVariable("CLIENT_SECRET");
 
     if (!stop) {
       SpringApplication.run(UserModelApplication.class, args);

--- a/foundation/src/main/java/com/lambdaschool/marketplace/config/AuthorizationServerConfig.java
+++ b/foundation/src/main/java/com/lambdaschool/marketplace/config/AuthorizationServerConfig.java
@@ -19,14 +19,14 @@ import org.springframework.security.oauth2.provider.token.TokenStore;
 public class AuthorizationServerConfig
   extends AuthorizationServerConfigurerAdapter {
   /**
-   * Client Id is the user name for the client application. It is read from the environment variable OAUTHCLIENTID
+   * Client Id is the user name for the client application. It is read from the environment variable CLIENT_ID
    */
-  static final String CLIENT_ID = System.getenv("OAUTHCLIENTID");
+  static final String CLIENT_ID = System.getenv("CLIENT_ID");
 
   /**
-   * Client secret is the password for the client application. It is read from the environment variable OAUTHCLIENTSECRET
+   * Client secret is the password for the client application. It is read from the environment variable CLIENT_SECRET
    */
-  static final String CLIENT_SECRET = System.getenv("OAUTHCLIENTSECRET"); // read from environment variable
+  static final String CLIENT_SECRET = System.getenv("CLIENT_SECRET"); // read from environment variable
 
   /**
    * We are using username and password to authenticate a user

--- a/foundation/src/main/java/com/lambdaschool/marketplace/controllers/OpenController.java
+++ b/foundation/src/main/java/com/lambdaschool/marketplace/controllers/OpenController.java
@@ -110,8 +110,8 @@ public class OpenController {
     headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
     headers.setAccept(acceptableMediaTypes);
     headers.setBasicAuth(
-      System.getenv("OAUTHCLIENTID"),
-      System.getenv("OAUTHCLIENTSECRET")
+      System.getenv("CLIENT_ID"),
+      System.getenv("CLIENT_SECRET")
     );
 
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();


### PR DESCRIPTION
Propose changing client authorization environment variable names to CLIENT_ID and CLIENT_SECRET - proper snake case and easier to remember/type properly.